### PR TITLE
Focus protocol

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,2 +1,3 @@
-import Focus.Lens
-alias Focus.Lens
+import Focus
+alias Lens
+alias Prism

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+-   repo: local
+    hooks:
+    -   id: mix-test
+        name: 'elixir: mix test'
+        entry: mix test
+        language: system
+        files: \.exs$
+    -   id: mix-dialyzer
+        name: 'elixir: mix dialyzer'
+        entry: mix dialyzer
+        language: system
+        files: \.ex$
+    -   id: mix-credo
+        name: 'elixir: mix credo'
+        entry: mix credo
+        language: system
+        files: \.ex$

--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ To construct a lens:
   # A lens for the key "name"
   Focus.Lens.make_lens("name")
 
-  # A lens for the second item in a list/tuple:
+  # A lens for the second item in a tuple:
   Focus.Lens.make_lens(1)
 #+END_SRC
 
@@ -37,7 +37,7 @@ Lenses can be used to access and/or modify structured data:
   person = %{name: "Homer"}
   nameLens = Focus.Lens.make_lens(:name)
 
-  Focus.Lens.view!(nameLens, person) == "Homer"
+  Focus.Lens.view(nameLens, person) == "Homer"
   # true
 
   Focus.Lens.set(nameLens, person, "Bart")
@@ -93,19 +93,29 @@ Their real utility comes in operating on nested data. Lenses can be created by c
 #+END_SRC
 
 ** Functions 
-*** Lens creation
-  + =Focus.Lens.make_lens/1=
+*** Optic creation
+  + =Lens.make_lens/1=
+  + =Lens.make_lenses/1=
+  + =Prism.make_prism/1=
+  + =Prism.idx/1=
+*** Pre-made optics
+  + =Prism.ok/0=
+  + =Prism.error/0=
 
 *** Lens application
-  + =Focus.Lens.view!/2=
-  + =Focus.Lens.view/2=
-  + =Focus.Lens.set/3=
-  + =Focus.Lens.over/3=
-  + =Focus.Lens.apply_list/2=
+  + =Focus.view/2=
+  + =Focus.over/3=
+  + =Focus.set/3=
+  + =Focus.view_list/2=
+  + =Focus.has/2=
+  + =Focus.hasnt/2=
+  + =Focus.fix_view/2=
+  + =Focus.fix_over/3=
+  + =Focus.fix_set/3=
 
 *** Lens composition
-  + =Focus.Lens.compose/2, (~>)=
-  + =Focus.Lens.alongside/2=
+  + =Focus.compose/2, (~>)=
+  + =Focus.alongside/2=
  
 ** Installation
 
@@ -132,4 +142,4 @@ Their real utility comes in operating on nested data. Lenses can be created by c
 
 * Footnotes
 
-[fn:1] This library currently combines Lenses, Prisms, and Traversals in its implementation of Lens.
+[fn:1] This library currently combines Lenses and Prisms with Traversals in its implementation. Until v1.0.0, the API is subject to large and frequent change.

--- a/lib/focus.ex
+++ b/lib/focus.ex
@@ -7,12 +7,6 @@ defprotocol Focusable do
 
   @doc "Set the data that an optic focuses on."
   def set(optic, structure, value)
-
-  @doc "Create a new optic by combining two others."
-  def compose(optic, optic)
-
-  @doc "Infix of Focus.compose/2"
-  def (optic) ~> (optic)
 end
 
 defmodule Focus do
@@ -30,5 +24,56 @@ defmodule Focus do
 
   def set(optic, structure, v) do
     Focusable.set(optic, structure, v)
+  end
+
+  @doc """
+  Compose with most general lens on the left
+
+  ## Examples
+
+      iex> marge = %{
+      ...>   name: "Marge",
+      ...>   address: %{
+      ...>     street: "123 Fake St.",
+      ...>     city: "Springfield"
+      ...>   }
+      ...> }
+      iex> address_lens = Lens.make_lens(:address)
+      iex> street_lens = Lens.make_lens(:street)
+      iex> composed = Focus.compose(address_lens, street_lens)
+      iex> Focus.view(composed, marge)
+      "123 Fake St."
+  """
+  def compose(%Lens{get: get_x, put: set_x}, %Lens{get: get_y, put: set_y}) do
+    %Lens{
+      get: fn s ->
+      get_y.(get_x.(s))
+    end,
+      put: fn s ->
+        fn f ->
+          set_x.(s).(set_y.(get_x.(s)).(f))
+        end
+      end
+    }
+  end
+
+  @doc """
+  Infix lens composition
+
+  ## Examples
+
+      iex> import Focus
+      iex> marge = %{name: "Marge", address: %{
+      ...>   local: %{number: 123, street: "Fake St."},
+      ...>   city: "Springfield"}
+      ...> }
+      iex> address_lens = Lens.make_lens(:address)
+      iex> local_lens = Lens.make_lens(:local)
+      iex> street_lens = Lens.make_lens(:street)
+      iex> address_lens ~> local_lens ~> street_lens |> Focus.view(marge)
+      "Fake St."
+  """
+  def x ~> y do
+    compose(x, y)
   end
 end

--- a/lib/focus.ex
+++ b/lib/focus.ex
@@ -1,4 +1,4 @@
-defprotocol Focus do
+defprotocol Focusable do
   @doc "View the data that an optic focuses on."
   def view(optic, structure)
 
@@ -13,4 +13,22 @@ defprotocol Focus do
 
   @doc "Infix of Focus.compose/2"
   def (optic) ~> (optic)
+end
+
+defmodule Focus do
+  alias Focus.Types
+
+  @spec view(Types.optic, Types.traversable) :: any | nil
+  def view(optic, structure) do
+    Focusable.view(optic, structure)
+  end
+
+  @spec over(Types.optic, Types.traversable, ((any) -> any)) :: Types.traversable
+  def over(optic, structure, f) do
+    Focusable.over(optic, structure, f)
+  end
+
+  def set(optic, structure, v) do
+    Focusable.set(optic, structure, v)
+  end
 end

--- a/lib/focus.ex
+++ b/lib/focus.ex
@@ -147,7 +147,7 @@ defmodule Focus do
       iex> name |> Focus.has(%{name: "Homer"})
       true
   """
-  @spec has(Types.optic, Types.traversable) :: bool
+  @spec has(Types.optic, Types.traversable) :: boolean
   def has(optic, structure) do
     case Focus.view(optic, structure) do
       nil -> false
@@ -169,6 +169,6 @@ defmodule Focus do
   iex> name |> Focus.hasnt(%{name: "Homer"})
   false
   """
-  @spec hasnt(Types.optic, Types.traversable) :: bool
+  @spec hasnt(Types.optic, Types.traversable) :: boolean
   def hasnt(optic, structure), do: !has(optic, structure)
 end

--- a/lib/focus.ex
+++ b/lib/focus.ex
@@ -1,9 +1,16 @@
-defmodule Focus do
-  @moduledoc """
-  Shared elements for the Focus modules.
-  """
-  @type product     :: map | struct | tuple
-  @type sum         :: list
-  @type traversable :: product | sum
-  @type maybe       :: {:ok, any} | {:error, any}
+defprotocol Focus do
+  @doc "View the data that an optic focuses on."
+  def view(optic, structure)
+
+  @doc "Modify the data that an optic focuses on."
+  def over(optic, structure, f)
+
+  @doc "Set the data that an optic focuses on."
+  def set(optic, structure, value)
+
+  @doc "Create a new optic by combining two others."
+  def compose(optic, optic)
+
+  @doc "Infix of Focus.compose/2"
+  def (optic) ~> (optic)
 end

--- a/lib/focus.ex
+++ b/lib/focus.ex
@@ -12,6 +12,8 @@ end
 defmodule Focus do
   alias Focus.Types
 
+  @moduledoc "Common functions usable by lenses, prisms, and traversals."
+
   @spec view(Types.optic, Types.traversable) :: any | nil
   def view(optic, structure) do
     Focusable.view(optic, structure)
@@ -132,5 +134,41 @@ defmodule Focus do
     end
   end
 
+  @doc """
+  Check whether an optic target is present in a data structure.
 
+  ## Examples
+
+      iex> first_elem = Prism.idx(1)
+      iex> first_elem |> Focus.has([0])
+      false
+
+      iex> name = Lens.make_lens(:name)
+      iex> name |> Focus.has(%{name: "Homer"})
+      true
+  """
+  @spec has(Types.optic, Types.traversable) :: bool
+  def has(optic, structure) do
+    case Focus.view(optic, structure) do
+      nil -> false
+      {:error, _} -> false
+      _   -> true
+    end
+  end
+
+  @doc """
+  Check whether an optic target is not present in a data structure.
+
+  ## Examples
+
+  iex> first_elem = Prism.idx(1)
+  iex> first_elem |> Focus.hasnt([0])
+  true
+
+  iex> name = Lens.make_lens(:name)
+  iex> name |> Focus.hasnt(%{name: "Homer"})
+  false
+  """
+  @spec hasnt(Types.optic, Types.traversable) :: bool
+  def hasnt(optic, structure), do: !has(optic, structure)
 end

--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -101,7 +101,7 @@ defmodule Lens do
   def safe_view(%Lens{} = lens, structure) do
     res = Focus.view(lens, structure)
     case res do
-      nil -> {:error, :bad_lens_path}
+      nil -> {:error, {:lens, :bad_path}}
       _   -> {:ok, res}
     end
   end

--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -14,7 +14,7 @@ defmodule Lens do
   }
 
   @doc """
-  Define a lens to focus on a part of a data structure.
+  Define a lens to Focus on a part of a data structure.
 
   ## Examples
 
@@ -89,7 +89,7 @@ defmodule Lens do
   end
 
   @doc """
-  Get a piece of a data structure that a lens focuses on;
+  Get a piece of a data structure that a lens Focuses on;
   returns {:ok, data} | {:error, :bad_lens_path}
 
   ## Examples
@@ -129,6 +129,7 @@ defmodule Lens do
       Focus.view(lens, structure)
     end
   end
+
   @doc """
   Compose a pair of lenses to operate at the same level as one another.
   Calling Focus.view/2, Focus.over/3, or Focus.set/3 on an alongside composed
@@ -182,9 +183,9 @@ defmodule Lens do
     end
   end
 
-  defimpl Focus do
+  defimpl Focusable do
     @doc """
-    View the data that an optic focuses on.
+    View the data that an optic Focuses on.
 
     ## Examples
 
@@ -205,7 +206,7 @@ defmodule Lens do
     end
 
     @doc """
-    Modify the part of a data structure that a lens focuses on.
+    Modify the part of a data structure that a lens Focuses on.
 
     ## Examples
 
@@ -222,7 +223,7 @@ defmodule Lens do
     end
 
     @doc """
-    Update the part of a data structure the lens focuses on.
+    Update the part of a data structure the lens Focuses on.
 
     ## Examples
 
@@ -234,7 +235,7 @@ defmodule Lens do
         iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
         iex> address_lens = Lens.make_lens(:address)
         iex> street_lens = Lens.make_lens(:street)
-        iex> composed = Focus.compose(address_lens, street_lens)
+        iex> composed = Focusable.compose(address_lens, street_lens)
         iex> Focus.set(composed, marge, "42 Wallaby Way")
         %{name: "Marge", address: %{street: "42 Wallaby Way", city: "Springfield"}}
     """
@@ -259,7 +260,7 @@ defmodule Lens do
         ...> }
         iex> address_lens = Lens.make_lens(:address)
         iex> street_lens = Lens.make_lens(:street)
-        iex> composed = Focus.compose(address_lens, street_lens)
+        iex> composed = Focusable.compose(address_lens, street_lens)
         iex> Focus.view(composed, marge)
         "123 Fake St."
     """
@@ -281,7 +282,7 @@ defmodule Lens do
 
     ## Examples
 
-    iex> import Focus
+    iex> import Focusable
     iex> marge = %{name: "Marge", address: %{
     ...>   local: %{number: 123, street: "Fake St."},
     ...>   city: "Springfield"}
@@ -293,7 +294,7 @@ defmodule Lens do
     "Fake St."
     """
     def x ~> y do
-      Focus.compose(x, y)
+      compose(x, y)
     end
 
   end

--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -235,7 +235,7 @@ defmodule Lens do
         iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
         iex> address_lens = Lens.make_lens(:address)
         iex> street_lens = Lens.make_lens(:street)
-        iex> composed = Focusable.compose(address_lens, street_lens)
+        iex> composed = Focus.compose(address_lens, street_lens)
         iex> Focus.set(composed, marge, "42 Wallaby Way")
         %{name: "Marge", address: %{street: "42 Wallaby Way", city: "Springfield"}}
     """
@@ -245,57 +245,5 @@ defmodule Lens do
         setter.(structure).(val)
       end
     end
-
-    @doc """
-    Compose with most general lens on the left
-
-    ## Examples
-
-        iex> marge = %{
-        ...>   name: "Marge",
-        ...>   address: %{
-        ...>     street: "123 Fake St.",
-        ...>     city: "Springfield"
-        ...>   }
-        ...> }
-        iex> address_lens = Lens.make_lens(:address)
-        iex> street_lens = Lens.make_lens(:street)
-        iex> composed = Focusable.compose(address_lens, street_lens)
-        iex> Focus.view(composed, marge)
-        "123 Fake St."
-    """
-    def compose(%Lens{get: get_x, put: set_x}, %Lens{get: get_y, put: set_y}) do
-      %Lens{
-        get: fn s ->
-        get_y.(get_x.(s))
-      end,
-        put: fn s ->
-          fn f ->
-            set_x.(s).(set_y.(get_x.(s)).(f))
-          end
-        end
-      }
-    end
-
-    @doc """
-    Infix lens composition
-
-    ## Examples
-
-    iex> import Focusable
-    iex> marge = %{name: "Marge", address: %{
-    ...>   local: %{number: 123, street: "Fake St."},
-    ...>   city: "Springfield"}
-    ...> }
-    iex> address_lens = Lens.make_lens(:address)
-    iex> local_lens = Lens.make_lens(:local)
-    iex> street_lens = Lens.make_lens(:street)
-    iex> address_lens ~> local_lens ~> street_lens |> Focus.view(marge)
-    "Fake St."
-    """
-    def x ~> y do
-      compose(x, y)
-    end
-
   end
 end

--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -1,8 +1,8 @@
-defmodule Focus.Lens do
-  alias Focus.Lens
+defmodule Lens do
+  alias Focus.Types
 
   @moduledoc """
-  Experimenting with functional lenses.
+  Lenses combine getters and setters for keys in data structures.
   """
 
   @enforce_keys [:get, :put]
@@ -18,7 +18,6 @@ defmodule Focus.Lens do
 
   ## Examples
 
-      iex> alias Focus.Lens
       iex> person = %{name: "Homer"}
       iex> name_lens = Lens.make_lens(:name)
       iex> name_lens.get.(person)
@@ -52,99 +51,41 @@ defmodule Focus.Lens do
   end
 
   @doc """
-  Compose with most general lens on the left
+  Partially apply a lens to Focus.over/3, returning a function that takes a
+  Types.traversable and an update function.
 
   ## Examples
 
-      iex> alias Focus.Lens
-      iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
-      iex> address_lens = Lens.make_lens(:address)
-      iex> street_lens = Lens.make_lens(:street)
-      iex> composed = Lens.compose(address_lens, street_lens)
-      iex> Lens.view(composed, marge)
-      {:ok, "123 Fake St."}
+  iex> upcase_name = Lens.make_lens(:name)
+  ...> |> Lens.fix_over(&String.upcase/1)
+  iex> %{name: "Bart", parents: {"Homer", "Marge"}}
+  ...> |> upcase_name.()
+  %{name: "BART", parents: {"Homer", "Marge"}}
   """
-  def compose(%Lens{get: get_x, put: set_x}, %Lens{get: get_y, put: set_y}) do
-    %Lens{
-      get: fn s ->
-        get_y.(get_x.(s))
-      end,
-      put: fn s ->
-        fn f ->
-          set_x.(s).(set_y.(get_x.(s)).(f))
-        end
-      end
-    }
+  @spec fix_over(Lens.t, ((any) -> any)) :: ((Types.traversable) -> Types.traversable)
+  def fix_over(%Lens{} = lens, f \\ fn x -> x end) when is_function(f) do
+    fn structure ->
+      Focus.over(lens, structure, f)
+    end
   end
 
   @doc """
-  Infix lens composition
+  Partially apply a lens to Focus.set/3, returning a function that takes a
+  Types.traversable and a new value.
 
   ## Examples
 
-      iex> import Focus.Lens
-      iex> alias Focus.Lens
-      iex> marge = %{name: "Marge", address: %{
-      ...>   local: %{number: 123, street: "Fake St."},
-      ...>   city: "Springfield"}
-      ...> }
-      iex> address_lens = Lens.make_lens(:address)
-      iex> local_lens = Lens.make_lens(:local)
-      iex> street_lens = Lens.make_lens(:street)
-      iex> address_lens ~> local_lens ~> street_lens |> Lens.view!(marge)
-      "Fake St."
+      iex> name_setter = Lens.make_lens(:name)
+      ...> |> Lens.fix_set
+      iex> %{name: "Bart", parents: {"Homer", "Marge"}}
+      ...> |> name_setter.("Lisa")
+      %{name: "Lisa", parents: {"Homer", "Marge"}}
   """
-  def x ~> y do
-    Lens.compose(x, y)
-  end
-
-  @doc """
-  Compose a pair of lenses to operate at the same level as one another.
-  Calling Lens.view/2, Lens.over/3, or Lens.set/3 on an alongside composed
-  pair returns a two-element tuple of the result.
-
-  ## Examples
-
-      iex> alias Focus.Lens
-      iex> nums = [1,2,3,4,5,6]
-      iex> Lens.alongside(Lens.make_lens(0), Lens.make_lens(3))
-      ...> |> Lens.view!(nums)
-      {1, 4}
-
-      iex> alias Focus.Lens
-      iex> bart = %{name: "Bart", parents: {"Homer", "Marge"}, age: 10}
-      iex> Lens.alongside(Lens.make_lens(:name), Lens.make_lens(:age))
-      ...> |> Lens.view!(bart)
-      {"Bart", 10}
-  """
-  @spec alongside(Lens.t, Lens.t) :: Lens.t
-  def alongside(%Lens{get: get_x, put: set_x}, %Lens{get: get_y, put: set_y}) do
-    %Lens{
-      get: fn s ->
-        {get_x.(s), get_y.(s)}
-      end,
-      put: fn s ->
-        fn f ->
-          {set_x.(s).(f), set_y.(s).(f)}
-        end
-      end
-    }
-  end
-
-  @doc """
-  Get a piece of a data structure that a lens focuses on.
-
-  ## Examples
-
-      iex> alias Focus.Lens
-      iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
-      iex> name_lens = Lens.make_lens(:name)
-      iex> Lens.view!(name_lens, marge)
-      "Marge"
-  """
-  @spec view!(Lens.t, Focus.traversable) :: any | nil
-  def view!(%Lens{get: get}, structure) do
-    get.(structure)
+  @spec fix_set(Lens.t) :: ((Types.traversable, any) -> Types.traversable)
+  def fix_set(%Lens{} = lens) do
+    fn structure, val ->
+      Focus.set(lens, structure, val)
+    end
   end
 
   @doc """
@@ -153,15 +94,14 @@ defmodule Focus.Lens do
 
   ## Examples
 
-      iex> alias Focus.Lens
       iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
       iex> name_lens = Lens.make_lens(:name)
-      iex> Lens.view(name_lens, marge)
+      iex> Lens.safe_view(name_lens, marge)
       {:ok, "Marge"}
   """
-  @spec view(Lens.t, Focus.traversable) :: {:error, :bad_arg} | {:ok, any}
-  def view(%Lens{} = lens, structure) do
-    res = view!(lens, structure)
+  @spec safe_view(Lens.t, Types.traversable) :: {:error, :bad_arg} | {:ok, any}
+  def safe_view(%Lens{} = lens, structure) do
+    res = Focus.view(lens, structure)
     case res do
       nil -> {:error, :bad_lens_path}
       _   -> {:ok, res}
@@ -169,12 +109,11 @@ defmodule Focus.Lens do
   end
 
   @doc """
-  Fix Lens.view!/2 on a given lens. This partially applies Lens.view/2 with the given
-  lens and returns a function that takes a Focus.traversable structure.
+  Fix Focus.view/2 on a given lens. This partially applies Focus.view/2 with the given
+  lens and returns a function that takes a Types.traversable structure.
 
   ## Examples
 
-      iex> alias Focus.Lens
       iex> view_name = Lens.make_lens(:name)
       ...> |> Lens.fix_view
       iex> homer = %{name: "Homer"}
@@ -184,99 +123,45 @@ defmodule Focus.Lens do
       ...> |> Enum.map(&view_name.(&1))
       ["Homer", "Marge", "Bart"]
   """
-  @spec fix_view(Lens.t) :: (Focus.traversable -> any)
+  @spec fix_view(Lens.t) :: (Types.traversable -> any)
   def fix_view(%Lens{} = lens) do
     fn structure ->
-      Lens.view!(lens, structure)
+      Focus.view(lens, structure)
     end
   end
-
   @doc """
-  Modify the part of a data structure that a lens focuses on.
+  Compose a pair of lenses to operate at the same level as one another.
+  Calling Focus.view/2, Focus.over/3, or Focus.set/3 on an alongside composed
+  pair returns a two-element tuple of the result.
 
   ## Examples
 
-      iex> alias Focus.Lens
-      iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
-      iex> name_lens = Lens.make_lens(:name)
-      iex> Lens.over(name_lens, marge, &String.upcase/1)
-      %{name: "MARGE", address: %{street: "123 Fake St.", city: "Springfield"}}
+  iex> nums = [1,2,3,4,5,6]
+  iex> Lens.alongside(Lens.make_lens(0), Lens.make_lens(3))
+  ...> |> Focus.view(nums)
+  {1, 4}
+
+  iex> bart = %{name: "Bart", parents: {"Homer", "Marge"}, age: 10}
+  iex> Lens.alongside(Lens.make_lens(:name), Lens.make_lens(:age))
+  ...> |> Focus.view(bart)
+  {"Bart", 10}
   """
-  @spec over(Lens.t, Focus.traversable, (any -> any)) :: Focus.traversable
-  def over(%Lens{put: setter} = lens, structure, f) do
-    with {:ok, d} <- Lens.view(lens, structure) do
-      setter.(structure).(f.(d))
-    end
+  @spec alongside(Lens.t, Lens.t) :: Lens.t
+  def alongside(%Lens{get: get_x, put: set_x}, %Lens{get: get_y, put: set_y}) do
+    %Lens{
+      get: fn s ->
+      {get_x.(s), get_y.(s)}
+    end,
+      put: fn s ->
+        fn f ->
+          {set_x.(s).(f), set_y.(s).(f)}
+        end
+      end
+    }
   end
 
   @doc """
-  Partially apply a lens to Lens.over/3, returning a function that takes a
-  Focus.traversable and an update function.
-
-  ## Examples
-
-  iex> alias Focus.Lens
-  iex> upcase_name = Lens.make_lens(:name)
-  ...> |> Lens.fix_over(&String.upcase/1)
-  iex> %{name: "Bart", parents: {"Homer", "Marge"}}
-  ...> |> upcase_name.()
-  %{name: "BART", parents: {"Homer", "Marge"}}
-  """
-  @spec fix_over(Lens.t, ((any) -> any)) :: ((Focus.traversable) -> Focus.traversable)
-  def fix_over(%Lens{} = lens, f \\ fn x -> x end) when is_function(f) do
-    fn structure ->
-      Lens.over(lens, structure, f)
-    end
-  end
-
-  @doc """
-  Update the part of a data structure the lens focuses on.
-
-  ## Examples
-
-      iex> alias Focus.Lens
-      iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
-      iex> name_lens = Lens.make_lens(:name)
-      iex> Lens.set(name_lens, marge, "Homer")
-      %{name: "Homer", address: %{street: "123 Fake St.", city: "Springfield"}}
-
-      iex> alias Focus.Lens
-      iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
-      iex> address_lens = Lens.make_lens(:address)
-      iex> street_lens = Lens.make_lens(:street)
-      iex> composed = Lens.compose(address_lens, street_lens)
-      iex> Lens.set(composed, marge, "42 Wallaby Way")
-      %{name: "Marge", address: %{street: "42 Wallaby Way", city: "Springfield"}}
-  """
-  @spec set(Lens.t, Focus.traversable, any) :: Focus.traversable
-  def set(%Lens{put: setter} = lens, structure, val) do
-    with {:ok, _d} <- Lens.view(lens, structure) do
-      setter.(structure).(val)
-    end
-  end
-
-  @doc """
-  Partially apply a lens to Lens.set/3, returning a function that takes a
-  Focus.traversable and a new value.
-
-  ## Examples
-
-      iex> alias Focus.Lens
-      iex> name_setter = Lens.make_lens(:name)
-      ...> |> Lens.fix_set
-      iex> %{name: "Bart", parents: {"Homer", "Marge"}}
-      ...> |> name_setter.("Lisa")
-      %{name: "Lisa", parents: {"Homer", "Marge"}}
-  """
-  @spec fix_set(Lens.t) :: ((Focus.traversable, any) -> Focus.traversable)
-  def fix_set(%Lens{} = lens) do
-    fn structure, val ->
-      Lens.set(lens, structure, val)
-    end
-  end
-
-  @doc """
-  Given a list of lenses and a structure, apply Lens.view for each lens
+  Given a list of lenses and a structure, apply Focus.view for each lens
   to the structure.
 
   ## Examples
@@ -286,14 +171,130 @@ defmodule Focus.Lens do
       ...>   job: "Nuclear Safety Inspector",
       ...>   children: ["Bart", "Lisa", "Maggie"]
       ...> }
-      iex> lenses = [Focus.Lens.make_lens(:name), Focus.Lens.make_lens(:children)]
-      iex> Focus.Lens.apply_list(lenses, homer)
+      iex> lenses = [Lens.make_lens(:name), Lens.make_lens(:children)]
+      iex> Lens.apply_list(lenses, homer)
       ["Homer", ["Bart", "Lisa", "Maggie"]]
   """
-  @spec apply_list(list(Lens.t), Focus.traversable) :: [any]
+  @spec apply_list(list(Lens.t), Types.traversable) :: [any]
   def apply_list(lenses, structure) when is_list(lenses) do
     for lens <- lenses do
-      Lens.view!(lens, structure)
+      Focus.view(lens, structure)
     end
+  end
+
+  defimpl Focus do
+    @doc """
+    View the data that an optic focuses on.
+
+    ## Examples
+
+        iex> marge = %{
+        ...>   name: "Marge",
+        ...>   address: %{
+        ...>     street: "123 Fake St.",
+        ...>     city: "Springfield"
+        ...>   }
+        ...> }
+        iex> name_lens = Lens.make_lens(:name)
+        iex> Focus.view(name_lens, marge)
+        "Marge"
+    """
+    @spec view(Lens.t, Types.traversable) :: any | nil
+    def view(%Lens{get: get}, structure) do
+      get.(structure)
+    end
+
+    @doc """
+    Modify the part of a data structure that a lens focuses on.
+
+    ## Examples
+
+        iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
+        iex> name_lens = Lens.make_lens(:name)
+        iex> Focus.over(name_lens, marge, &String.upcase/1)
+        %{name: "MARGE", address: %{street: "123 Fake St.", city: "Springfield"}}
+    """
+    @spec over(Lens.t, Types.traversable, (any -> any)) :: Types.traversable
+    def over(%Lens{put: setter} = lens, structure, f) do
+      with {:ok, d} <- Lens.safe_view(lens, structure) do
+        setter.(structure).(f.(d))
+      end
+    end
+
+    @doc """
+    Update the part of a data structure the lens focuses on.
+
+    ## Examples
+
+        iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
+        iex> name_lens = Lens.make_lens(:name)
+        iex> Focus.set(name_lens, marge, "Homer")
+        %{name: "Homer", address: %{street: "123 Fake St.", city: "Springfield"}}
+
+        iex> marge = %{name: "Marge", address: %{street: "123 Fake St.", city: "Springfield"}}
+        iex> address_lens = Lens.make_lens(:address)
+        iex> street_lens = Lens.make_lens(:street)
+        iex> composed = Focus.compose(address_lens, street_lens)
+        iex> Focus.set(composed, marge, "42 Wallaby Way")
+        %{name: "Marge", address: %{street: "42 Wallaby Way", city: "Springfield"}}
+    """
+    @spec set(Lens.t, Types.traversable, any) :: Types.traversable
+    def set(%Lens{put: setter} = lens, structure, val) do
+      with {:ok, _d} <- Lens.safe_view(lens, structure) do
+        setter.(structure).(val)
+      end
+    end
+
+    @doc """
+    Compose with most general lens on the left
+
+    ## Examples
+
+        iex> marge = %{
+        ...>   name: "Marge",
+        ...>   address: %{
+        ...>     street: "123 Fake St.",
+        ...>     city: "Springfield"
+        ...>   }
+        ...> }
+        iex> address_lens = Lens.make_lens(:address)
+        iex> street_lens = Lens.make_lens(:street)
+        iex> composed = Focus.compose(address_lens, street_lens)
+        iex> Focus.view(composed, marge)
+        "123 Fake St."
+    """
+    def compose(%Lens{get: get_x, put: set_x}, %Lens{get: get_y, put: set_y}) do
+      %Lens{
+        get: fn s ->
+        get_y.(get_x.(s))
+      end,
+        put: fn s ->
+          fn f ->
+            set_x.(s).(set_y.(get_x.(s)).(f))
+          end
+        end
+      }
+    end
+
+    @doc """
+    Infix lens composition
+
+    ## Examples
+
+    iex> import Focus
+    iex> marge = %{name: "Marge", address: %{
+    ...>   local: %{number: 123, street: "Fake St."},
+    ...>   city: "Springfield"}
+    ...> }
+    iex> address_lens = Lens.make_lens(:address)
+    iex> local_lens = Lens.make_lens(:local)
+    iex> street_lens = Lens.make_lens(:street)
+    iex> address_lens ~> local_lens ~> street_lens |> Focus.view(marge)
+    "Fake St."
+    """
+    def x ~> y do
+      Focus.compose(x, y)
+    end
+
   end
 end

--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -40,6 +40,7 @@ defmodule Lens do
   defp getter(%{__struct__: _} = s, x), do: Map.get(s, x)
   defp getter(s, x) when is_map(s), do: Access.get(s, x)
   defp getter(s, x) when is_tuple(s), do: elem(s, x)
+  defp getter(_, _), do: {:error, {:lens, :bad_data_structure}}
 
   defp setter(s, x, f) when is_map(s), do: Map.put(s, x, f)
   defp setter(s, x, f) when is_tuple(s) do
@@ -47,6 +48,7 @@ defmodule Lens do
     |> Tuple.delete_at(x)
     |> Tuple.insert_at(x, f)
   end
+  defp setter(_s, _x, _f), do: {:error, {:lens, :bad_data_structure}}
 
   @doc """
   Partially apply a lens to Focus.over/3, returning a function that takes a

--- a/lib/prism/prism.ex
+++ b/lib/prism/prism.ex
@@ -44,6 +44,64 @@ defmodule Prism do
   defp setter(s, x, f) when is_list(s), do: List.replace_at(s, x, f)
 
   @doc """
+  A prism that matches an {:ok, _} tuple.
+
+  ## Examples
+
+      iex> ok = Prism.ok
+      iex> ok |> Focus.view({:ok, 5})
+      {:ok, 5}
+      iex> ok |> Focus.set({:ok, 5}, "Banana")
+      {:ok, "Banana"}
+      iex> ok |> Focus.view({:error, :oops})
+      {:error, {:prism, :bad_path}}
+  """
+  @spec ok() :: Prism.t
+  def ok() do
+    %Prism{
+      get: fn s -> get_ok(s) end,
+      put: fn s ->
+        fn f ->
+          set_ok(s, f)
+        end
+      end
+    }
+  end
+  defp get_ok({:ok, x}), do: x
+  defp get_ok({:error, _}), do: nil
+  defp set_ok({:ok, _x}, f), do: {:ok, f}
+
+  @doc """
+  A prism that matches an {:error, _} tuple.
+  Note that on a successful match, view/set/over will
+  return {:ok, _}
+
+  ## Examples
+
+  iex> error = Prism.error
+  iex> error |> Focus.view({:error, 5})
+  {:ok, 5}
+  iex> error |> Focus.set({:error, 5}, "Banana")
+  {:ok, "Banana"}
+  iex> error |> Focus.view({:ok, :oops})
+  {:error, {:prism, :bad_path}}
+  """
+  @spec error() :: Prism.t
+  def error() do
+    %Prism{
+      get: fn s -> get_error(s) end,
+      put: fn s ->
+        fn f ->
+          set_error(s, f)
+        end
+      end
+    }
+  end
+  defp get_error({:error, x}), do: x
+  defp get_error({:ok, _}), do: nil
+  defp set_error({:error, _x}, f), do: {:ok, f}
+
+  @doc """
   Partially apply a prism to Focus.over/3, returning a function that takes a
   Types.traversable and an update function.
 

--- a/lib/prism/prism.ex
+++ b/lib/prism/prism.ex
@@ -5,7 +5,8 @@ defmodule Prism do
   Prisms are like lenses, but used when the view focused on may not exist.
 
   This includes lists and sum types (although not backed by an explicit Maybe type,
-  we will include the [{:ok, any} | {:error}] convention as a value that a prism can focus on).
+  the [{:ok, any} | {:error}] convention is explicitly supported as a value that
+  a prism can focus on).
   """
 
   @enforce_keys [:get, :put]
@@ -132,42 +133,6 @@ defmodule Prism do
   defp get_error({:ok, _}), do: nil
   defp set_error({:error, _x}, f), do: {:ok, f}
 
-  @doc """
-  Partially apply a prism to Focus.over/3, returning a function that takes a
-  Types.traversable and an update function.
-
-  ## Examples
-
-      iex> fst = Prism.make_prism(0)
-      iex> states = [:maryland, :texas, :illinois]
-      iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
-      ["MARYLAND", :texas, :illinois]
-  """
-  @spec fix_over(Prism.t, ((any) -> any)) :: ((Types.traversable) -> Types.traversable)
-  def fix_over(%Prism{} = prism, f \\ fn x -> x end) when is_function(f) do
-    fn structure ->
-      Focus.over(prism, structure, f)
-    end
-  end
-
-  @doc """
-  Partially apply a prism to Focus.set/3, returning a function that takes a
-  Types.traversable and a new value.
-
-  ## Examples
-
-      iex> fst = Prism.make_prism(0)
-      iex> states = [:maryland, :texas, :illinois]
-      iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
-      ["MARYLAND", :texas, :illinois]
-  """
-  @spec fix_set(Prism.t) :: ((Types.traversable, any) -> Types.traversable)
-  def fix_set(%Prism{} = prism) do
-    fn structure, val ->
-      Focus.set(prism, structure, val)
-    end
-  end
-
   defimpl Focusable do
     @doc """
     Get a piece of a data structure that a prism focuses on;
@@ -175,7 +140,7 @@ defmodule Prism do
 
     ## Examples
 
-        iex> fst = Prism.make_prism(0)
+        iex> fst = Prism.idx(0)
         iex> states = [:maryland, :texas, :illinois]
         iex> Focus.view(fst, states)
         {:ok, :maryland}
@@ -194,7 +159,7 @@ defmodule Prism do
 
     ## Examples
 
-        iex> fst = Prism.make_prism(0)
+        iex> fst = Prism.idx(0)
         iex> states = [:maryland, :texas, :illinois]
         iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
         ["MARYLAND", :texas, :illinois]
@@ -211,7 +176,7 @@ defmodule Prism do
 
     ## Examples
 
-        iex> fst = Prism.make_prism(0)
+        iex> fst = Prism.idx(0)
         iex> states = [:maryland, :texas, :illinois]
         iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
         ["MARYLAND", :texas, :illinois]

--- a/lib/prism/prism.ex
+++ b/lib/prism/prism.ex
@@ -44,6 +44,22 @@ defmodule Prism do
   defp setter(s, x, f) when is_list(s), do: List.replace_at(s, x, f)
 
   @doc """
+  A prism that focuses on an index in a list.
+
+  ## Examples
+
+      iex> first_elem = Prism.idx(0)
+      iex> first_elem |> Focus.view([1,2,3,4,5])
+      {:ok, 1}
+
+      iex> bad_index = Prism.idx(10)
+      iex> bad_index |> Focus.view([1,2,3])
+      {:error, {:prism, :bad_path}}
+  """
+  @spec idx(number) :: Prism.t
+  def idx(num) when is_number(num), do: make_prism(num)
+
+  @doc """
   A prism that matches an {:ok, _} tuple.
 
   ## Examples

--- a/lib/prism/prism.ex
+++ b/lib/prism/prism.ex
@@ -40,8 +40,23 @@ defmodule Prism do
     }
   end
 
-  defp getter(s, x) when is_list(s), do: get_in(s, [Access.at(x)])
-  defp setter(s, x, f) when is_list(s), do: List.replace_at(s, x, f)
+  defp getter(s, x) when is_list(s) do
+    if Keyword.keyword?(s) do
+      Keyword.get(s, x)
+    else
+      get_in(s, [Access.at(x)])
+    end
+  end
+  defp getter(_s, _x), do: {:error, {:prism, :bad_data_structure}}
+
+  defp setter(s, x, f) when is_list(s) do
+    if Keyword.keyword?(s) do
+      Keyword.put(s, x, f)
+    else
+      List.replace_at(s, x, f)
+    end
+  end
+  defp setter(_s, _x, _f), do: {:error, {:prism, :bad_data_structure}}
 
   @doc """
   A prism that focuses on an index in a list.

--- a/lib/prism/prism.ex
+++ b/lib/prism/prism.ex
@@ -1,0 +1,137 @@
+defmodule Prism do
+  alias Focus.Types
+
+  @moduledoc """
+  Prisms are like lenses, but used when the view focused on may not exist.
+
+  This includes lists and sum types (although not backed by an explicit Maybe type,
+  we will include the [{:ok, any} | {:error}] convention as a value that a prism can focus on).
+  """
+
+  @enforce_keys [:get, :put]
+  defstruct [:get, :put]
+
+  @type t :: %Prism{
+    get: ((any) -> any),
+    put: (((any) -> any) -> any)
+  }
+
+  @doc """
+  Define a prism to focus on a part of a data structure.
+
+  ## Examples
+
+      iex> fst = Prism.make_prism(0)
+      iex> states = [:maryland, :texas, :illinois]
+      iex> fst.get.(states)
+      :maryland
+      iex> fst.put.(states).(:california)
+      [:california, :texas, :illinois]
+  """
+  @spec make_prism(any) :: Prism.t
+  def make_prism(path) do
+    %Prism{
+      get: fn s -> getter(s, path) end,
+      put: fn s ->
+        fn f ->
+          setter(s, path, f)
+        end
+      end
+    }
+  end
+
+  defp getter(s, x) when is_list(s), do: get_in(s, [Access.at(x)])
+  defp setter(s, x, f) when is_list(s), do: List.replace_at(s, x, f)
+
+  @doc """
+  Partially apply a prism to Focus.over/3, returning a function that takes a
+  Types.traversable and an update function.
+
+  ## Examples
+
+      iex> fst = Prism.make_prism(0)
+      iex> states = [:maryland, :texas, :illinois]
+      iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
+      ["MARYLAND", :texas, :illinois]
+  """
+  @spec fix_over(Prism.t, ((any) -> any)) :: ((Types.traversable) -> Types.traversable)
+  def fix_over(%Prism{} = prism, f \\ fn x -> x end) when is_function(f) do
+    fn structure ->
+      Focus.over(prism, structure, f)
+    end
+  end
+
+  @doc """
+  Partially apply a prism to Focus.set/3, returning a function that takes a
+  Types.traversable and a new value.
+
+  ## Examples
+
+      iex> fst = Prism.make_prism(0)
+      iex> states = [:maryland, :texas, :illinois]
+      iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
+      ["MARYLAND", :texas, :illinois]
+  """
+  @spec fix_set(Prism.t) :: ((Types.traversable, any) -> Types.traversable)
+  def fix_set(%Prism{} = prism) do
+    fn structure, val ->
+      Focus.set(prism, structure, val)
+    end
+  end
+
+  defimpl Focusable do
+    @doc """
+    Get a piece of a data structure that a prism focuses on;
+    returns {:ok, data} | {:error, :bad_prism_path}
+
+    ## Examples
+
+        iex> fst = Prism.make_prism(0)
+        iex> states = [:maryland, :texas, :illinois]
+        iex> Focus.view(fst, states)
+        {:ok, :maryland}
+    """
+    @spec view(Prism.t, Types.traversable) :: {:error, {:prism, :bad_path}} | {:ok, any}
+    def view(%Prism{get: get}, structure) do
+      res = get.(structure)
+      case res do
+        nil -> {:error, {:prism, :bad_path}}
+        _   -> {:ok, res}
+      end
+    end
+
+    @doc """
+    Modify the part of a data structure that a prism focuses on.
+
+    ## Examples
+
+        iex> fst = Prism.make_prism(0)
+        iex> states = [:maryland, :texas, :illinois]
+        iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
+        ["MARYLAND", :texas, :illinois]
+    """
+    @spec over(Prism.t, Types.traversable, (any -> any)) :: Types.traversable
+    def over(%Prism{put: put} = prism, structure, f) do
+      with {:ok, data_view} <- view(prism, structure) do
+        put.(structure).(f.(data_view))
+      end
+    end
+
+    @doc """
+    Update the part of a data structure the prism focuses on.
+
+    ## Examples
+
+        iex> fst = Prism.make_prism(0)
+        iex> states = [:maryland, :texas, :illinois]
+        iex> Focus.over(fst, states, &String.upcase(Atom.to_string(&1)))
+        ["MARYLAND", :texas, :illinois]
+    """
+    @spec set(Prism.t, Types.traversable, any) :: Types.traversable
+    def set(%Prism{put: put} = prism, structure, val) do
+      with {:ok, _data_view} <- view(prism, structure) do
+        put.(structure).(val)
+      end
+    end
+  end
+end

--- a/lib/types.ex
+++ b/lib/types.ex
@@ -1,0 +1,10 @@
+defmodule Focus.Types do
+  @moduledoc """
+  Shared elements for the Focus modules.
+  """
+  @type product     :: map | struct | tuple
+  @type sum         :: list
+  @type traversable :: product | sum
+  @type maybe       :: {:ok, any} | {:error, any}
+  @type optic       :: Focus.Lens.t
+end

--- a/lib/types.ex
+++ b/lib/types.ex
@@ -6,5 +6,5 @@ defmodule Focus.Types do
   @type sum         :: list
   @type traversable :: product | sum
   @type maybe       :: {:ok, any} | {:error, any}
-  @type optic       :: Focus.Lens.t
+  @type optic       :: Lens.t
 end

--- a/test/focus_test.exs
+++ b/test/focus_test.exs
@@ -1,4 +1,4 @@
 defmodule FocusTest do
   use ExUnit.Case
-  doctest Focus.Lens
+  doctest Focusable.Lens
 end

--- a/test/focus_test.exs
+++ b/test/focus_test.exs
@@ -1,4 +1,5 @@
 defmodule FocusTest do
   use ExUnit.Case
-  doctest Focusable.Lens
+  import Focus
+  doctest Focus
 end

--- a/test/focus_test.exs
+++ b/test/focus_test.exs
@@ -1,0 +1,4 @@
+defmodule FocusTest do
+  use ExUnit.Case
+  doctest Focus.Lens
+end

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -1,9 +1,8 @@
 defmodule Focus.LensTest do
   use ExUnit.Case
   use Quixir
-  import Focus.Lens
-  alias Focus.Lens
-  doctest Focus.Lens
+  import Focus
+  doctest Lens
 
   setup do
     test_structure = %{
@@ -28,80 +27,77 @@ defmodule Focus.LensTest do
   test "Lens law: Put/Get - get a value that is set" do
     ptest structure: map(like: %{name: string()}), new_name: string() do
       lens = Lens.make_lens(:name)
-      assert Lens.view!(lens, Lens.set(lens, structure, new_name)) == new_name
+      assert Focus.view(lens, Focus.set(lens, structure, new_name)) == new_name
     end
   end
 
   test "Lens law: Get/Put - setting a value that is retrieved is doing nothing" do
     ptest structure: map(like: %{name: string()}) do
       lens = Lens.make_lens(:name)
-      assert Lens.set(lens, structure, Lens.view!(lens, structure)) == structure
+      assert Focus.set(lens, structure, Focus.view(lens, structure)) == structure
     end
   end
 
   test "Lens law: Put/Put - last set value wins" do
     ptest structure: map(like: %{name: string()}), name1: string(), name2: string() do
       lens = Lens.make_lens(:name)
-      assert Lens.view!(lens, Lens.set(lens, Lens.set(lens, structure, name1), name2)) == name2
+      assert Focus.view(lens, Focus.set(lens, Focus.set(lens, structure, name1), name2)) == name2
     end
   end
 
   test "get data from a map", %{test_structure: test_structure} do
     name_lens = Lens.make_lens(:name)
-    assert Lens.view!(name_lens, test_structure) == "Homer"
-    assert Lens.view(name_lens, test_structure) == {:ok, "Homer"}
+    assert Focus.view(name_lens, test_structure) == "Homer"
   end
 
   test "set data in a map", %{test_structure: test_structure} do
     name_lens = Lens.make_lens(:name)
-    assert Lens.set(name_lens, test_structure, "Bart") == %{test_structure | name: "Bart"}
+    assert Focus.set(name_lens, test_structure, "Bart") == %{test_structure | name: "Bart"}
   end
 
   test "manipulate data in a map", %{test_structure: test_structure} do
     name_lens = Lens.make_lens(:name)
-    assert Lens.over(name_lens, test_structure, &String.reverse/1) ==
+    assert Focus.over(name_lens, test_structure, &String.reverse/1) ==
       %{test_structure | name: "remoH"}
   end
 
   test "get data from a list", %{test_structure: test_structure} do
     list_lens = Lens.make_lens(:list)
     second_elem = Lens.make_lens(1)
-    assert (list_lens ~> second_elem |> Lens.view!(test_structure)) == 4
-    assert (list_lens ~> second_elem |> Lens.view(test_structure)) == {:ok, 4}
+    assert (list_lens ~> second_elem |> Focus.view(test_structure)) == 4
   end
 
   test "set data in a list", %{test_structure: test_structure} do
     list_lens = Lens.make_lens(:list)
     second_elem = Lens.make_lens(1)
-    assert (list_lens ~> second_elem |> Lens.set(test_structure, "Banana")) ==
+    assert (list_lens ~> second_elem |> Focus.set(test_structure, "Banana")) ==
       %{test_structure | list: [2, "Banana", 8, 16, 32]}
   end
 
   test "manipulate data in a list", %{test_structure: test_structure} do
     list_lens = Lens.make_lens(:list)
     second_elem = Lens.make_lens(1)
-    assert (list_lens ~> second_elem |> Lens.over(test_structure, fn x -> x * x * x end)) ==
+    assert (list_lens ~> second_elem |> Focus.over(test_structure, fn x -> x * x * x end)) ==
       %{test_structure | list: [2, 64, 8, 16, 32]}
   end
 
   test "get data from a tuple", %{test_structure: test_structure} do
     tuple_lens = Lens.make_lens(:tuple)
     first_elem = Lens.make_lens(0)
-    assert (tuple_lens ~> first_elem |> Lens.view!(test_structure)) == :a
-    assert (tuple_lens ~> first_elem |> Lens.view(test_structure)) == {:ok, :a}
+    assert (tuple_lens ~> first_elem |> Focus.view(test_structure)) == :a
   end
 
   test "set data in a tuple", %{test_structure: test_structure} do
     tuple_lens = Lens.make_lens(:tuple)
     first_elem = Lens.make_lens(0)
-    assert (tuple_lens ~> first_elem |> Lens.set(test_structure, "Pineapple")) ==
+    assert (tuple_lens ~> first_elem |> Focus.set(test_structure, "Pineapple")) ==
       %{test_structure | tuple: {"Pineapple", :b, :c}}
   end
 
   test "manipulate data in a tuple", %{test_structure: test_structure} do
     tuple_lens = Lens.make_lens(:tuple)
     first_elem = Lens.make_lens(0)
-    assert (tuple_lens ~> first_elem |> Lens.over(test_structure, &Atom.to_string/1)) ==
+    assert (tuple_lens ~> first_elem |> Focus.over(test_structure, &Atom.to_string/1)) ==
       %{test_structure | tuple: {"a", :b, :c}}
   end
 
@@ -109,15 +105,14 @@ defmodule Focus.LensTest do
     address = Lens.make_lens(:address)
     locale = Lens.make_lens(:locale)
     street = Lens.make_lens(:street)
-    assert (address ~> locale ~> street |> Lens.view!(test_structure)) == "Fake St."
-    assert (address ~> locale ~> street |> Lens.view(test_structure)) == {:ok, "Fake St."}
+    assert (address ~> locale ~> street |> Focus.view(test_structure)) == "Fake St."
   end
 
   test "set data in a deep map", %{test_structure: test_structure} do
     address = Lens.make_lens(:address)
     locale = Lens.make_lens(:locale)
     street = Lens.make_lens(:street)
-    assert (address ~> locale ~> street |> Lens.set(test_structure, "Evergreen Terrace")) ==
+    assert (address ~> locale ~> street |> Focus.set(test_structure, "Evergreen Terrace")) ==
       %{test_structure | address: %{
            test_structure.address | locale: %{
              test_structure.address.locale | street: "Evergreen Terrace"}}}
@@ -127,7 +122,7 @@ defmodule Focus.LensTest do
     address = Lens.make_lens(:address)
     locale = Lens.make_lens(:locale)
     street = Lens.make_lens(:street)
-    assert (address ~> locale ~> street |> Lens.over(test_structure, &String.upcase/1)) ==
+    assert (address ~> locale ~> street |> Focus.over(test_structure, &String.upcase/1)) ==
       %{test_structure | address: %{
            test_structure.address | locale: %{
              test_structure.address.locale | street: "FAKE ST."}}}

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -1,8 +1,9 @@
 defmodule Focus.LensTest do
   use ExUnit.Case
   use Quixir
-  import Focusable
+  import Focus
   doctest Lens
+  doctest Focusable.Lens
 
   setup do
     test_structure = %{

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -1,4 +1,4 @@
-defmodule Focus.LensTest do
+defmodule LensTest do
   use ExUnit.Case
   use Quixir
   import Focus
@@ -60,26 +60,6 @@ defmodule Focus.LensTest do
     name_lens = Lens.make_lens(:name)
     assert Focus.over(name_lens, test_structure, &String.reverse/1) ==
       %{test_structure | name: "remoH"}
-  end
-
-  test "get data from a list", %{test_structure: test_structure} do
-    list_lens = Lens.make_lens(:list)
-    second_elem = Lens.make_lens(1)
-    assert (list_lens ~> second_elem |> Focus.view(test_structure)) == 4
-  end
-
-  test "set data in a list", %{test_structure: test_structure} do
-    list_lens = Lens.make_lens(:list)
-    second_elem = Lens.make_lens(1)
-    assert (list_lens ~> second_elem |> Focus.set(test_structure, "Banana")) ==
-      %{test_structure | list: [2, "Banana", 8, 16, 32]}
-  end
-
-  test "manipulate data in a list", %{test_structure: test_structure} do
-    list_lens = Lens.make_lens(:list)
-    second_elem = Lens.make_lens(1)
-    assert (list_lens ~> second_elem |> Focus.over(test_structure, fn x -> x * x * x end)) ==
-      %{test_structure | list: [2, 64, 8, 16, 32]}
   end
 
   test "get data from a tuple", %{test_structure: test_structure} do

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -1,7 +1,7 @@
 defmodule Focus.LensTest do
   use ExUnit.Case
   use Quixir
-  import Focus
+  import Focusable
   doctest Lens
 
   setup do

--- a/test/prism_test.exs
+++ b/test/prism_test.exs
@@ -1,0 +1,48 @@
+defmodule PrismTest do
+  use ExUnit.Case
+  use Quixir
+  import Focus
+  doctest Prism
+  doctest Focusable.Prism
+
+  setup do
+    test_structure = %{
+      name: "Homer",
+      address: %{
+        locale: %{
+          number: 123,
+          street: "Fake St.",
+        },
+        city: "Springfield",
+      },
+      list: [2, 4, 8, 16, 32],
+      tuple: {:a, :b, :c},
+      deep_list: %{
+        values: [5, 10, 15]
+      }
+    }
+
+    {:ok, test_structure: test_structure}
+  end
+
+  test "get data from a list", %{test_structure: test_structure} do
+    list_prism = Lens.make_lens(:list)
+    second_elem = Prism.make_prism(1)
+    assert (list_prism ~> second_elem |> Focus.view(test_structure)) == 4
+  end
+
+  test "set data in a list", %{test_structure: test_structure} do
+    list_prism = Lens.make_lens(:list)
+    second_elem = Prism.make_prism(1)
+    assert (list_prism ~> second_elem |> Focus.set(test_structure, "Banana")) ==
+      %{test_structure | list: [2, "Banana", 8, 16, 32]}
+  end
+
+  test "manipulate data in a list", %{test_structure: test_structure} do
+    list_prism = Lens.make_lens(:list)
+    second_elem = Prism.make_prism(1)
+    assert (list_prism ~> second_elem |> Focus.over(test_structure, fn x -> x * x * x end)) ==
+      %{test_structure | list: [2, 64, 8, 16, 32]}
+  end
+
+end


### PR DESCRIPTION
Add a protocol for functionality that should be common among lenses, prisms, and traversals. 

+ Add prisms for lists and `[{:ok, _} | {:error, reason}]` tuples - 56cf190

+ Add `Prism.idx` to generate a prism for accessing a list via index - ab27d46

+ Handle keyword lists in `Prism` - cf0b179