### PR TITLE
Lens protocol

### DIFF
--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -28,44 +28,17 @@ defmodule Lens do
       iex> name_lens |> Focus.set(person, "Bart")
       %{name: "Bart"}
   """
-  @spec make_lens(list) :: Lens.t
+  @spec make_lens(any) :: Lens.t
   def make_lens(path) do
     %Lens{
-      get: fn s -> getter(s, path) end,
+      get: fn s -> Lensable.getter(s, path) end,
       put: fn s ->
         fn f ->
-          setter(s, path, f)
+          Lensable.setter(s, path, f)
         end
       end
     }
   end
-
-  defp getter(%{__struct__: _} = s, x), do: Map.get(s, x)
-  defp getter(s, x) when is_map(s), do: Access.get(s, x)
-  defp getter(s, x) when is_tuple(s), do: elem(s, x)
-  defp getter(s, x) when is_list(s) do
-    if Keyword.keyword?(s) do
-      Keyword.get(s, x)
-    else
-      get_in(s, [Access.at(x)])
-    end
-  end
-  defp getter(_, _), do: {:error, {:lens, :bad_data_structure}}
-
-  defp setter(s, x, f) when is_map(s), do: Map.put(s, x, f)
-  defp setter(s, x, f) when is_list(s) do
-    if Keyword.keyword?(s) do
-      Keyword.put(s, x, f)
-    else
-      List.replace_at(s, x, f)
-    end
-  end
-  defp setter(s, x, f) when is_tuple(s) do
-    s
-    |> Tuple.delete_at(x)
-    |> Tuple.insert_at(x, f)
-  end
-  defp setter(_s, _x, _f), do: {:error, {:lens, :bad_data_structure}}
 
   @doc """
   Automatically generate the valid lenses for the supplied map-like data structure.

--- a/lib/lens/lensable.ex
+++ b/lib/lens/lensable.ex
@@ -1,0 +1,45 @@
+defprotocol Lensable do
+  @fallback_to_any true
+
+  @doc "A function to get a value out of a data structure"
+  def getter(structure, view)
+
+  @doc "A function to set a value out of a data structure"
+  def setter(structure, view, func)
+end
+
+defimpl Lensable, for: Map do
+  def getter(s, x), do: Access.get(s, x)
+  def setter(s, x, f), do: Map.put(s, x, f)
+end
+
+defimpl Lensable, for: Tuple do
+  def getter(s, x), do: elem(s, x)
+  def setter(s, x, f) do
+    s
+    |> Tuple.delete_at(x)
+    |> Tuple.insert_at(x, f)
+  end
+end
+
+defimpl Lensable, for: List do
+  def getter(s, x) do
+    if Keyword.keyword?(s) do
+      Keyword.get(s, x)
+    else
+      get_in(s, [Access.at(x)])
+    end
+  end
+  def setter(s, x, f) do
+    if Keyword.keyword?(s) do
+      Keyword.put(s, x, f)
+    else
+      List.replace_at(s, x, f)
+    end
+  end
+end
+
+defimpl Lensable, for: Any do
+  def getter(_, _), do: {:error, {:lens, :bad_data_structure}}
+  def setter(_s, _x, _f), do: {:error, {:lens, :bad_data_structure}}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Focus.Mixfile do
      version: "0.2.2",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
+     consolidate_protocols: Mix.env != :test,
      start_permanent: Mix.env == :prod,
      description: description(),
      package: package(),

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -2,6 +2,13 @@ defmodule LensTest do
   use ExUnit.Case
   use Quixir
   import Focus
+
+  defmodule PersonExample do
+    @moduledoc "Used in the deflenses doctest example"
+    import Lens
+    deflenses name: nil, age: nil
+  end
+
   doctest Lens
   doctest Focusable.Lens
 


### PR DESCRIPTION
Move getter/setter generations into a protocol so that user defined data types/structs can implement getters/setters and make get lens generation via `Lens.make_lens/1`