### PR TITLE
Use Focus.over/3 to implement Focus.set/3

### DIFF
--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -207,10 +207,8 @@ defmodule Lens do
         %{name: "Marge", address: %{street: "42 Wallaby Way", city: "Springfield"}}
     """
     @spec set(Lens.t, Types.traversable, any) :: Types.traversable
-    def set(%Lens{put: setter} = lens, structure, val) do
-      with {:ok, _d} <- Lens.safe_view(lens, structure) do
-        setter.(structure).(val)
-      end
+    def set(lens, structure, val) do
+      over(lens, structure, fn _ -> val end)
     end
   end
 


### PR DESCRIPTION
Hi there,

stumbling across Focus made me read up on functional optics and wanting to learn more. Therefore: Thanks for writing Focus and also for writing about it!  😄

I read through the code a little and thought this might be interesting:

By constructing a constant function, we can just treat `Focus.set/3` as a special case of `Focus.over/3`.

Cheers