### PR TITLE
Fix for setting a value when lenses compose to a bad path

### DIFF
--- a/lib/focus.ex
+++ b/lib/focus.ex
@@ -53,11 +53,21 @@ defmodule Focus do
   def compose(%{get: get_x, put: set_x}, %{get: get_y, put: set_y}) do
     %Lens{
       get: fn s ->
-        get_y.(get_x.(s))
+        case get_x.(s) do
+          {:error, {:lens, :bad_path}} ->
+            {:error, {:lens, :bad_path}}
+          x ->
+            get_y.(x)
+        end
       end,
       put: fn s ->
         fn f ->
-          set_x.(s).(set_y.(get_x.(s)).(f))
+          case get_x.(s) do
+            {:error, {:lens, :bad_path}} ->
+              {:error, {:lens, :bad_path}}
+            x ->
+              set_x.(s).(set_y.(x).(f))
+          end
         end
       end
     }

--- a/lib/focus.ex
+++ b/lib/focus.ex
@@ -53,8 +53,8 @@ defmodule Focus do
   def compose(%{get: get_x, put: set_x}, %{get: get_y, put: set_y}) do
     %Lens{
       get: fn s ->
-      get_y.(get_x.(s))
-    end,
+        get_y.(get_x.(s))
+      end,
       put: fn s ->
         fn f ->
           set_x.(s).(set_y.(get_x.(s)).(f))

--- a/lib/lens/lens.ex
+++ b/lib/lens/lens.ex
@@ -222,11 +222,11 @@ defmodule Lens do
       iex> Lens.safe_view(name_lens, marge)
       {:ok, "Marge"}
   """
-  @spec safe_view(Lens.t, Types.traversable) :: {:error, :bad_arg} | {:ok, any}
+  @spec safe_view(Lens.t, Types.traversable) :: {:error, {:lens, :bad_path}} | {:ok, any}
   def safe_view(%Lens{} = lens, structure) do
     res = Focus.view(lens, structure)
     case res do
-      nil -> {:error, {:lens, :bad_path}}
+      {:error, {:lens, :bad_path}} -> {:error, {:lens, :bad_path}}
       _   -> {:ok, res}
     end
   end

--- a/lib/lens/lensable.ex
+++ b/lib/lens/lensable.ex
@@ -10,7 +10,13 @@ end
 
 defimpl Lensable, for: Map do
   def getter(s, x), do: Access.get(s, x)
-  def setter(s, x, f), do: Map.put(s, x, f)
+  def setter(s, x, f) do
+    if Map.has_key?(s, x) do
+      Map.put(s, x, f)
+    else
+      s
+    end
+  end
 end
 
 defimpl Lensable, for: Tuple do

--- a/lib/lens/lensable.ex
+++ b/lib/lens/lensable.ex
@@ -9,7 +9,8 @@ defprotocol Lensable do
 end
 
 defimpl Lensable, for: Map do
-  def getter(s, x), do: Access.get(s, x)
+  def getter(s, x), do: Access.get(s, x, {:error, {:lens, :bad_path}})
+  def setter({:error, {:lens, :bad_path}} = e), do: e
   def setter(s, x, f) do
     if Map.has_key?(s, x) do
       Map.put(s, x, f)

--- a/test/focus_test.exs
+++ b/test/focus_test.exs
@@ -31,8 +31,13 @@ defmodule FocusTest do
     ~> lenses.name
     |> Focus.set(test_structure, "Test")
 
-    refute Map.has_key?(test_structure.address, :name)
-    refute Map.has_key?(updated.address, :name)
-    assert updated == test_structure
+    assert updated == {:error, {:lens, :bad_path}}
+  end
+
+  test "Trying to access non-existing lenses returns an error", %{test_structure: test_structure} do
+    nope_lens = Lens.make_lens(:nope)
+
+    assert Focus.view(nope_lens, test_structure) == {:error, {:lens, :bad_path}}
+    assert Focus.set(nope_lens, test_structure, "nothing") == {:error, {:lens, :bad_path}}
   end
 end

--- a/test/focus_test.exs
+++ b/test/focus_test.exs
@@ -2,4 +2,37 @@ defmodule FocusTest do
   use ExUnit.Case
   import Focus
   doctest Focus
+
+  setup do
+    test_structure = %{
+      name: "Homer",
+      address: %{
+        locale: %{
+          number: 123,
+          street: "Fake St.",
+        },
+        city: "Springfield",
+      },
+      list: [2, 4, 8, 16, 32],
+      tuple: {:a, :b, :c},
+      deep_list: %{
+        values: [5, 10, 15]
+      }
+    }
+
+    {:ok, test_structure: test_structure}
+  end
+
+  test "Composing set doesn't add new keys", %{test_structure: test_structure} do
+    lenses = Lens.make_lenses(test_structure)
+
+    updated = lenses.address
+    ~> lenses.name
+    ~> lenses.name
+    |> Focus.set(test_structure, "Test")
+
+    refute Map.has_key?(test_structure.address, :name)
+    refute Map.has_key?(updated.address, :name)
+    assert updated == test_structure
+  end
 end

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -69,6 +69,16 @@ defmodule LensTest do
       %{test_structure | name: "remoH"}
   end
 
+  test "view a key with a value of nil in a map" do
+    s = %{name: nil}
+    assert Focus.view(Lens.make_lens(:name), s) == nil
+  end
+
+  test "update a key with a value of nil in a map" do
+    s = %{name: nil}
+    assert Focus.set(Lens.make_lens(:name), s, "Bart") == %{name: "Bart"}
+  end
+
   test "get data from a tuple", %{test_structure: test_structure} do
     tuple_lens = Lens.make_lens(:tuple)
     first_elem = Lens.make_lens(0)
@@ -135,5 +145,4 @@ defmodule LensTest do
     assert (list_lens ~> second_elem |> Focus.over(test_structure, fn x -> x * x * x end)) ==
       %{test_structure | list: [2, 64, 8, 16, 32]}
   end
-
 end


### PR DESCRIPTION
Unintentional behavior allowed setting a value (invariably resulted in `{:error,
{:lens, :bad_path}}`) when attempting to compose two lenses into a nested
structure, neither of which presently exist in the structure.

See `test/focus_test.exs` for an example.