### PR TITLE
Fix composition when there's an empty list in the path

### DIFF
--- a/lib/lens/lensable.ex
+++ b/lib/lens/lensable.ex
@@ -34,7 +34,7 @@ defimpl Lensable, for: List do
     if Keyword.keyword?(s) && !Enum.empty?(s) do
       Keyword.get(s, x)
     else
-      if is_number(x) do
+      if is_number(x) && !Enum.empty?(s) do
         get_in(s, [Access.at(x)])
       else
         {:error, {:lens, :bad_path}}

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -154,8 +154,20 @@ defmodule LensTest do
     i = Lens.idx(0)
     v = Lens.make_lens(:value)
 
-    assert Lens.safe_view(l ~> i ~> v, bad_path) == {:error, {:lens, :bad_data_structure}}
+    assert Lens.safe_view(l ~> i ~> v, bad_path) == {:error, {:lens, :bad_path}}
     assert Lens.safe_view(l ~> l ~> v, bad_path) == {:error, {:lens, :bad_path}}
     assert Lens.safe_view(l ~> i ~> v, good_path) == {:ok, :hello}
+  end
+
+  test "safe_view doesn't crash when composing into multiple non-existing paths" do
+    data = %{a: []}
+    a = Lens.make_lens(:a)
+    b = Lens.make_lens(:b)
+    c = Lens.make_lens(:c)
+    d = Lens.make_lens(:d)
+    i0 = Lens.idx(0)
+
+    a ~> b ~> c ~> d |> Lens.safe_view(data) == {:error, {:lens, :bad_path}}
+    a ~> i0 ~> b ~> c |> Lens.safe_view(data) == {:error, {:lens, :bad_path}}
   end
 end


### PR DESCRIPTION
`get_in([], [Access.at(0)]` returns nil; need to catch the empty list and return
an error that compose knows what to do with.

Fixes #19 