### PR TITLE
Support arbitrary structs

### DIFF
--- a/lib/lens/lensable.ex
+++ b/lib/lens/lensable.ex
@@ -54,6 +54,19 @@ defimpl Lensable, for: List do
 end
 
 defimpl Lensable, for: Any do
-  def getter(_, _), do: {:error, {:lens, :bad_data_structure}}
-  def setter(_s, _x, _f), do: {:error, {:lens, :bad_data_structure}}
+  @bad_data_structure_error {:error, {:lens, :bad_data_structure}}
+  def getter(s, x) do
+    with %_type{} <- s do
+     Lensable.getter(Map.from_struct(s), x)
+    else
+      _ -> @bad_data_structure_error
+    end
+  end
+  def setter(s, x, f) do
+    with %type{} <- s do
+      struct(type, Lensable.setter(Map.from_struct(s), x, f))
+    else
+      _ -> @bad_data_structure_error
+    end
+  end
 end

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -9,6 +9,10 @@ defmodule LensTest do
     deflenses name: nil, age: nil
   end
 
+  defmodule BasicStruct do
+    defstruct name: ""
+  end
+
   doctest Lens
   doctest Focusable.Lens
 
@@ -169,5 +173,18 @@ defmodule LensTest do
 
     assert a ~> b ~> c ~> d |> Lens.safe_view(data) == {:error, {:lens, :bad_path}}
     assert a ~> i0 ~> b ~> c |> Lens.safe_view(data) == {:error, {:lens, :bad_path}}
+  end
+
+  test "lenses can be used on arbitrary structs" do
+    alias LensTest.BasicStruct
+
+    foo = %BasicStruct{name: "foo"}
+    name = Lens.make_lens(:name)
+    assert name |> Focus.view(foo) === "foo"
+
+    bar = name |> Focus.set(foo, "bar")
+    assert bar === %BasicStruct{name: "bar"}
+
+    assert name |> Focus.view(bar) === "bar"
   end
 end


### PR DESCRIPTION
The `deflenses` macro allows you to easily create structs with the `Lensable` protocol implementation. However, sometimes you have many arbitrary structs (maybe from other libs) which would be tedious to provide the `Lensable` implementation for each of them.

With this modification to the `Any` fallback of the `Lensable` protocol you can use lenses with any struct in the same way you would use them with maps.